### PR TITLE
Update alt text for blog and category images

### DIFF
--- a/src/Resources/views/shop/category/index.blade.php
+++ b/src/Resources/views/shop/category/index.blade.php
@@ -38,7 +38,7 @@
                                         <h1 class="hero-main-title">{{ $category->name }}</h1>
                                         <img
                                         src="{{ '/storage/' . ( ( isset($category->image) && !empty($category->image) && !is_null($category->image) ) ? $category->image : 'placeholder-banner.jpg' ) }}"
-                                        alt="Blanditiis soluta et iste consectetur sapiente nobis ut perferendis fugiat veritatis incidunt dolore."
+                                        alt="{{ $category->name }}"
                                         class="card-img img-fluid img-thumbnail bg-fill">
                                     </div>
                                 </section>

--- a/src/Resources/views/shop/velocity/view.blade.php
+++ b/src/Resources/views/shop/velocity/view.blade.php
@@ -36,7 +36,7 @@
                                 <h1 class="hero-main-title">{{ $blog->name }}</h1>
                                 <img
                                     src="{{ '/storage/' . ( ( isset($blog->src) && !empty($blog->src) && !is_null($blog->src) ) ? $blog->src : 'placeholder-banner.jpg' ) }}"
-                                    alt="Blanditiis soluta et iste consectetur sapiente nobis ut perferendis fugiat veritatis incidunt dolore."
+                                    alt="{{ $blog->name }}"
                                     class="card-img img-fluid img-thumbnail bg-fill">
                             </div>
                         </section>


### PR DESCRIPTION
The alternative text for images in the blog and category views was updated. Previously, a placeholder text was used regardless of the content of the image. Now, the alt text will reflect the name of the blog or category, improving SEO and accessibility.