### PR TITLE
Change page titles in multiple views

### DIFF
--- a/src/Resources/views/shop/author/index.blade.php
+++ b/src/Resources/views/shop/author/index.blade.php
@@ -15,7 +15,7 @@
 <x-shop::layouts>
     {{-- Page Title --}}
     <x-slot:title>
-        {{ __('Blog Author Page') }}
+        Posts by {{ $author_data->author }}
     </x-slot>
 
     @push ('styles')

--- a/src/Resources/views/shop/category/index.blade.php
+++ b/src/Resources/views/shop/category/index.blade.php
@@ -15,7 +15,7 @@
 <x-shop::layouts>
     {{-- Page Title --}}
     <x-slot:title>
-        {{ __('Blog Category Page') }}
+        {{ $category->meta_title ?? ( $blog_seo_meta_title ?? ( $channel->home_seo['meta_title'] ?? '' ) ) }}
     </x-slot>
 
     @push ('styles')

--- a/src/Resources/views/shop/tag/index.blade.php
+++ b/src/Resources/views/shop/tag/index.blade.php
@@ -15,7 +15,7 @@
 <x-shop::layouts>
     {{-- Page Title --}}
     <x-slot:title>
-        {{ __('Blog Tag Page') }}
+        {{ $tag->meta_title ?? ( $blog_seo_meta_title ?? ( $channel->home_seo['meta_title'] ?? '' ) ) }}
     </x-slot>
 
     @push ('styles')

--- a/src/Resources/views/shop/velocity/index.blade.php
+++ b/src/Resources/views/shop/velocity/index.blade.php
@@ -15,7 +15,7 @@
 <x-shop::layouts>
     {{-- Page Title --}}
     <x-slot:title>
-        {{ __('Blog Page') }}
+        {{ $blog_seo_meta_title ?? ( $channel->home_seo['meta_title'] ?? '' ) }}
     </x-slot>
 
     @push ('styles')

--- a/src/Resources/views/shop/velocity/view.blade.php
+++ b/src/Resources/views/shop/velocity/view.blade.php
@@ -15,7 +15,7 @@
 <x-shop::layouts>
     {{-- Page Title --}}
     <x-slot:title>
-        {{ __('Single Blog Page') }}
+        {{ $blog->meta_title ?? ( $blog_seo_meta_title ?? ( $channel->home_seo['meta_title'] ?? '' ) ) }}
     </x-slot>
 
     @push ('styles')


### PR DESCRIPTION
Page titles in certain views including blog, category, tag, author, and velocity have been modified. Rather than using a generic title for each page, the title now dynamically reflects the respective meta title, which improves SEO and gives more context to the user. The default falls back to home SEO meta title or an empty string if no specific meta title is available.