### PR TITLE
Refactor blog_categories table schema

### DIFF
--- a/src/Database/Migrations/2023_03_21_175157_create_blog_categories_table.php
+++ b/src/Database/Migrations/2023_03_21_175157_create_blog_categories_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('slug');
-            $table->string('description');
+            $table->longText('description');
             $table->string('image');
             $table->boolean('status');
             $table->foreignId('parent_id')->default(0)->nullable();


### PR DESCRIPTION
Description column in the table schema for 'blog_categories' has been changed from string to longText. This allows storing detailed category descriptions, significantly enhancing flexibility.